### PR TITLE
Python 3 compatibility

### DIFF
--- a/sublime_info/SublimeInfo.py
+++ b/sublime_info/SublimeInfo.py
@@ -1,9 +1,13 @@
 # Load in core, 3rd party, and local dependencies
+from __future__ import absolute_import
 import os
 import re
 import subprocess
-from shutilwhich import which
-from errors import STNotResolvedError, STBadLocationError
+from sublime_info.errors import STNotResolvedError, STBadLocationError
+try:
+    from shutil import which
+except ImportError:  # python 2 fallback
+    from shutilwhich import which
 
 
 class SublimeInfo(object):

--- a/sublime_info/__init__.py
+++ b/sublime_info/__init__.py
@@ -1,6 +1,7 @@
 # Load in local modules for extension
-from sublime_info import SublimeInfo
-from errors import *
+from __future__ import absolute_import
+from sublime_info.SublimeInfo import SublimeInfo
+from sublime_info.errors import *
 
 # Define sugar methods
 def get_sublime_path():


### PR DESCRIPTION
- Using absolute imports
- Using `shutilswhich` as a python 2 fallback instead of the main sourch for `which`